### PR TITLE
Typo fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ One of the unique features of Ghostty is the ability to use custom shaders. This
 
 ## Themes
 * [Electron Highlighter](https://github.com/electron-highlighter/ghostty)
-* [Catpuccin](https://github.com/catppuccin/ghostty) - Soothing pastel theme for Ghostty
+* [Catppuccin](https://github.com/catppuccin/ghostty) - Soothing pastel theme for Ghostty
 * [Rosé Pine](https://github.com/rose-pine/ghostty) - Rosé Pine theme for Ghostty
 * [Kitty themes for Ghostty](https://github.com/hroi/ghostty-themes) - Kitty themes converted to Ghostty themes
 * [tinted-ghostty](https://github.com/bezhermoso/tinted-ghostty) - A tinted theming template for Ghostty with Base16 themes

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ For a full list of features, visit the [features section](https://ghostty.org/do
 * [GhosttyExtensions.jl](https://github.com/piechologist/GhosttyExtensions.jl) - A Julia package that supports some advanced features of Ghostty
 * [osscz](https://github.com/kontza/osscz) - Command-line application to dynamically change Ghostty's terminal themes based on SSH connections
 * [Apprentice-Ghostty](https://github.com/ethanfrogers/apprentice-ghostty) - A Vim Apprentice clone for Ghostty terminal emulator
-* [Ghosttty Base16 Converter](https://github.com/l0go/ghostty-base16-converter) - Convert from a base16 scheme to ghostty.
+* [Ghostty Base16 Converter](https://github.com/l0go/ghostty-base16-converter) - Convert from a base16 scheme to ghostty.
 * [Tree-sitter Ghostty](https://github.com/bezhermoso/tree-sitter-ghostty) - Tree-sitter grammar for Ghostty configuration files
 * [Ghostty Color Converter](https://github.com/almonk/ghostty-color-converter) - Convert colors to Ghostty
 * [Ghostsmith](https://github.com/vandorsx/ghostsmith) - Barebones CLI tool for saving custom generated Ghostty icons to file


### PR DESCRIPTION
Fixes the following typos

- Ghosttty  → Ghostty (Line 24)
- Catpuccin → Catppuccin (Line 42)